### PR TITLE
add None option for the tileGrid parameter, add line_width input parameter

### DIFF
--- a/arrowline.py
+++ b/arrowline.py
@@ -29,10 +29,22 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/jposada202020/CircuitPython_ArrowLine.git"
 
 
-def line_arrow(grid, x1, y1, x2, y2, arrow_length, palette, pal_index, pointer="A"):
+def line_arrow(
+    grid=None,
+    x1=0,
+    y1=0,
+    x2=10,
+    y2=10,
+    arrow_length=10,
+    palette=None,
+    pal_index=1,
+    line_width=1,
+    pointer="A",
+):
     """A Line Arrow utility.
 
-    :param grid: Tilegrid object where the bitmap will be located
+    :param grid: Tilegrid object where the bitmap will be located, set to None for
+     arbitrary placement of the `line_arrow` (default = None)
 
     :param int x1: line first point x coordinate
     :param int y1: line first point x coordinate
@@ -103,6 +115,9 @@ def line_arrow(grid, x1, y1, x2, y2, arrow_length, palette, pal_index, pointer="
 
     """
 
+    if palette is None:
+        raise "Must provide a valid palette"
+
     my_group = displayio.Group(max_size=2)
 
     angle = math.atan2((y2 - y1), (x2 - x1))
@@ -113,15 +128,22 @@ def line_arrow(grid, x1, y1, x2, y2, arrow_length, palette, pal_index, pointer="
     arrow_side_x = arrow_length // 2 * math.cos(angle2)
     arrow_side_y = arrow_length // 2 * math.sin(angle2)
 
-    start_x = grid.x + x2
-    start_y = grid.y + y2
+    if grid is not None:
+        x_reference = grid.x
+        y_reference = grid.y
+    else:
+        x_reference = 0
+        y_reference = 0
+
+    start_x = x_reference + x2
+    start_y = y_reference + y2
 
     arrow_base_x = start_x - x0
     arrow_base_y = start_y - y0
 
     end_line_x = x2 - x0
     end_line_y = y2 - y0
-    line_draw = _angledrectangle(x1, y1, end_line_x, end_line_y, stroke=1)
+    line_draw = _angledrectangle(x1, y1, end_line_x, end_line_y, stroke=line_width)
 
     right_x = math.ceil(arrow_base_x + arrow_side_x)
     right_y = math.ceil(arrow_base_y - arrow_side_y)
@@ -135,10 +157,10 @@ def line_arrow(grid, x1, y1, x2, y2, arrow_length, palette, pal_index, pointer="
 
     line_base = Polygon(
         points=[
-            (grid.x + line_draw[0][0], grid.y + line_draw[0][1]),
-            (grid.x + line_draw[1][0], grid.y + line_draw[1][1]),
-            (grid.x + line_draw[2][0], grid.y + line_draw[2][1]),
-            (grid.x + line_draw[3][0], grid.y + line_draw[3][1]),
+            (x_reference + line_draw[0][0], y_reference + line_draw[0][1]),
+            (x_reference + line_draw[1][0], y_reference + line_draw[1][1]),
+            (x_reference + line_draw[2][0], y_reference + line_draw[2][1]),
+            (x_reference + line_draw[3][0], y_reference + line_draw[3][1]),
         ]
     )
     line_vector_shape = VectorShape(
@@ -162,8 +184,8 @@ def line_arrow(grid, x1, y1, x2, y2, arrow_length, palette, pal_index, pointer="
         my_group.append(arrow_vector_shape)
 
     elif pointer == "C":
-        circle_center_x = grid.x + line_draw[2][0]
-        circle_center_y = grid.y + line_draw[2][1]
+        circle_center_x = x_reference + line_draw[2][0]
+        circle_center_y = y_reference + line_draw[2][1]
 
         circle_ending = Circle(3)
         circle_vector_shape = VectorShape(

--- a/arrowline.py
+++ b/arrowline.py
@@ -57,6 +57,7 @@ def line_arrow(
      same color for the arrow
     :param pal_index: pallet color index used in the bitmap to give the arrow line the color
      property
+    :param int line_width: the width of the arrow's line, in pixels (default = 1)
 
     :param str pointer: point type. Two pointers could be selected ``C`` Circle or ``A`` Arrow
      Defaults to Arrow


### PR DESCRIPTION
I needed an arrow, so I spent some time using the `line_arrow`.  I modified it to make it more suitable for my specific use.  Please consider whether these changes are desirable.

Main changes:
- I wanted to place an arrow against a vectorio rectangle (which isn't in a TileGrid), so I updated the arrow so you can send it `grid=None` and place the arrow anywhere you want.
- I wanted to change the width of my line, so I added an optional input parameter `line_width`.  The default value is 1.

A couple more comments:
- The use of the `palette` and the `pal_index` two parameters seems like a lot of work, particularly since the function takes just the one color and makes a new palette to create the vectorio.  I recommend either just taking a single RGB `color` as an input, or update it so you could choose to just send a single color **or** use the `palette` + `pal_index` combination.
- For angled arrows, there is a single pixel gap between the line and the arrow. I didn't dig down to figure out why yet.

This is a really great addition, looking forward to getting into into the new graphics home.