### PR TITLE
bug/remove-vectorio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@
 # SPDX-License-Identifier: MIT
 
 Adafruit-Blinka
-vectorio


### PR DESCRIPTION
Unless we're not following.... Vectorio is part of the CP core so it does not need to be called out in requirements.
Circup was unhappy with vectorio in the requirements. https://github.com/adafruit/circup/issues/122